### PR TITLE
DM: Add ioctl interface to retrieve RPMB key

### DIFF
--- a/core/vmmapi.c
+++ b/core/vmmapi.c
@@ -749,3 +749,9 @@ vm_get_cpu_state(struct vmctx *ctx, void *state_buf)
 {
 	return ioctl(ctx->fd, IC_PM_GET_CPU_STATE, state_buf);
 }
+
+int
+vm_get_rpmb_key(struct vmctx *ctx, void *key)
+{
+	return ioctl(ctx->fd, IC_GET_RPMB_KEY, key);
+}

--- a/include/public/vhm_ioctl_defs.h
+++ b/include/public/vhm_ioctl_defs.h
@@ -105,6 +105,10 @@
 #define IC_ID_PM_BASE                   0x60UL
 #define IC_PM_GET_CPU_STATE            _IC_ID(IC_ID, IC_ID_PM_BASE + 0x00)
 
+/* RPMB */
+#define IC_ID_RPMB                      0x70UL
+#define IC_GET_RPMB_KEY                _IC_ID(IC_ID, IC_ID_RPMB + 0x00)
+
 /**
  * struct vm_memseg - memory segment info for guest
  *

--- a/include/vmmapi.h
+++ b/include/vmmapi.h
@@ -161,5 +161,7 @@ int	vm_create_vcpu(struct vmctx *ctx, int vcpu_id);
 
 int	vm_get_cpu_state(struct vmctx *ctx, void *state_buf);
 
+int	vm_get_rpmb_key(struct vmctx *ctx, void *key);
+
 extern bool hugetlb;
 #endif	/* _VMMAPI_H_ */


### PR DESCRIPTION
Implement ioctl interface to retrieve RPMB key
from vhm.

Signed-off-by: Qi Yadong <yadong.qi@intel.com>